### PR TITLE
🔥 remove: Firestore 전송 데이터의 중복 날짜 필드 제거

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -198,8 +198,7 @@ function App() {
         await addDoc(collection(db, "visitors"), {
           ...visitor,
           location: roomLocation,
-          timestamp: serverTimestamp(),
-          date: new Date().toISOString().split('T')[0]
+          timestamp: serverTimestamp()
         });
       }
       
@@ -300,8 +299,7 @@ function App() {
         await addDoc(collection(db, "visitors"), {
           ...visitor,
           location: roomLocation,
-          timestamp: serverTimestamp(),
-          date: new Date().toISOString().split('T')[0]
+          timestamp: serverTimestamp()
         });
       }
       


### PR DESCRIPTION
## 📋 Summary
Firebase 전송 시 `date` 필드를 제거하고 `timestamp`만 저장하도록 정리했습니다.

## 🛠 Key Changes
**1. App.jsx**: AI/수동 전송 로직 모두에서 `date` 필드를 제거하고 `timestamp`만 전송하도록 수정  
**2. 데이터 일관성**: 중복 필드 제거로 서버 타임스탬프 기반 일원화

## 📸 Screenshots
1. 수정전
<img width="382" height="232" alt="{6F1A5C79-93F5-42EE-897C-C767049FF9F7}" src="https://github.com/user-attachments/assets/8d99e983-5f8a-400e-b365-995c067688f5" />

2. 수정후

<img width="412" height="212" alt="{DCBFA117-3358-4F40-9080-A3AAFFD070C2}" src="https://github.com/user-attachments/assets/34e28368-deab-4cc0-a591-579f73bf8480" />

