### PR TITLE
✨ feat: 모달 UX 개선 및 초기화 기능 추가

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -553,6 +553,7 @@ function App() {
             visitors={visitors}
             onRemove={removeVisitor}
             onAdd={addManualVisitor}
+            onReset={() => setVisitors([])}
           />
         </div>
 
@@ -626,11 +627,11 @@ const getStyles = (device) => {
       borderBottom: `2px solid ${RAIM_COLORS.BG}`
     },
     logoImage: { 
-      height: pick({ mobile: '60px', tabletA9: '70px', desktop: '100px' }), width: 'auto' 
+      height: pick({ mobile: '40px', tabletA9: '70px', desktop: '100px' }), width: 'auto' 
     },
     title: { 
       margin: 0, 
-      fontSize: pick({ mobile: '20px', tabletA9: '26px', desktop: '30px' }), 
+      fontSize: pick({ mobile: '15px', tabletA9: '26px', desktop: '30px' }), 
       color: RAIM_COLORS.DARK, 
       fontWeight: '800',
       textAlign: 'center',
@@ -659,7 +660,7 @@ const getStyles = (device) => {
     },
     modeSwitchButton: {
       padding: pick({ mobile: '14px', tabletA9: '19px', desktop: '20px' }),
-      fontSize: pick({ mobile: '17px', tabletA9: '20px', desktop: '21px' }),
+      fontSize: pick({ mobile: '13px', tabletA9: '20px', desktop: '21px' }),
       fontWeight: '800',
       backgroundColor: '#DC2626',
       color: 'white',

--- a/src/components/ScanConfirmModal.jsx
+++ b/src/components/ScanConfirmModal.jsx
@@ -250,18 +250,18 @@ export default function ScanConfirmModal({
 
         <div style={styles.buttonContainer}>
           <button 
-            style={styles.confirmButton}
-            onClick={onConfirm}
-          >
-            <Check size={22} />
-            {t('scanConfirm.confirmButton')}
-          </button>
-          <button 
             style={styles.editButton}
             onClick={onEdit}
           >
             <AlertCircle size={22} />
             {t('scanConfirm.cancelButton')}
+          </button>
+          <button 
+            style={styles.confirmButton}
+            onClick={onConfirm}
+          >
+            <Check size={22} />
+            {t('scanConfirm.confirmButton')}
           </button>
         </div>
       </div>

--- a/src/components/SuccessModal.jsx
+++ b/src/components/SuccessModal.jsx
@@ -1,4 +1,5 @@
 import { CheckCircle2 } from 'lucide-react';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { RAIM_COLORS } from '../constants';
 
@@ -35,6 +36,16 @@ const modalStyles = {
 
 export default function SuccessModal({ isOpen, onClose, count }) {
   const { t } = useTranslation();
+  
+  useEffect(() => {
+    if (isOpen) {
+      const timer = setTimeout(() => {
+        onClose();
+      }, 3000);
+      
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen, onClose]);
   
   if (!isOpen) return null;
   return (

--- a/src/components/VisitorList.jsx
+++ b/src/components/VisitorList.jsx
@@ -1,4 +1,4 @@
-import { ClipboardList, User, X, Plus, Minus } from 'lucide-react';
+import { ClipboardList, User, X, Plus, Minus, RotateCcw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { RAIM_COLORS } from '../constants';
@@ -24,13 +24,29 @@ const getStyles = (device) => {
       display: 'flex', alignItems: 'center', gap: pick({ mobile: '8px', tabletA9: '10px', desktop: '10px' }) 
     },
     cardTitle: { 
-      margin: 0, fontSize: pick({ mobile: '22px', tabletA9: '26px', desktop: '28px' }), 
+      margin: 0, fontSize: pick({ mobile: '15px', tabletA9: '26px', desktop: '28px' }), 
       color: RAIM_COLORS.DARK, fontWeight: '700' 
     },
     countBadge: { 
       backgroundColor: RAIM_COLORS.MEDIUM, color: 'white', 
       padding: pick({ mobile: '3px 10px', tabletA9: '4px 12px', desktop: '4px 12px' }), borderRadius: '16px', fontWeight: 'bold', 
-      fontSize: pick({ mobile: '18px', tabletA9: '22px', desktop: '24px' })
+      fontSize: pick({ mobile: '15px', tabletA9: '22px', desktop: '24px' })
+    },
+    resetButton: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '6px',
+      padding: pick({ mobile: '6px 12px', tabletA9: '8px 14px', desktop: '8px 14px' }),
+      backgroundColor: '#F3F4F6',
+      border: 'none',
+      borderRadius: '10px',
+      cursor: 'pointer',
+      fontSize: pick({ mobile: '13px', tabletA9: '16px', desktop: '16px' }),
+      fontWeight: '600',
+      color: RAIM_COLORS.MUTED,
+      transition: 'all 0.2s',
+      marginRight: '10px'
     },
     listContainer: { 
       flex: 1, overflowY: 'auto', paddingRight: '6px' 
@@ -51,11 +67,11 @@ const getStyles = (device) => {
       display: 'flex', justifyContent: 'center', alignItems: 'center', 
       flexShrink: 0, backgroundColor: RAIM_COLORS.BG, 
       color: RAIM_COLORS.DARK,
-      fontSize: pick({ mobile: '16px', tabletA9: '18px', desktop: '18px' }),
+      fontSize: pick({ mobile: '15px', tabletA9: '18px', desktop: '18px' }),
       fontWeight: '700'
     },
     listItemTitle: { 
-      fontWeight: '700', fontSize: pick({ mobile: '20px', tabletA9: '24px', desktop: '26px' }), color: RAIM_COLORS.DARK, 
+      fontWeight: '700', fontSize: pick({ mobile: '15px', tabletA9: '24px', desktop: '26px' }), color: RAIM_COLORS.DARK, 
       marginBottom: '4px'
     },
     badgeContainer: { 
@@ -63,20 +79,20 @@ const getStyles = (device) => {
     },
     badgeNeutral: { 
       display:'inline-flex', alignItems:'center', justifyContent:'center', 
-      fontSize: pick({ mobile: '16px', tabletA9: '20px', desktop: '22px' }), padding: '3px 8px', borderRadius: '6px', 
+      fontSize: pick({ mobile: '15px', tabletA9: '20px', desktop: '22px' }), padding: '3px 8px', borderRadius: '6px', 
       backgroundColor: RAIM_COLORS.GRAY_BG, color: RAIM_COLORS.GRAY_TXT, 
       fontWeight: '700', whiteSpace: 'nowrap', flexShrink: 0 
     },
     badgeAI: { 
       display:'inline-flex', alignItems:'center', justifyContent:'center', 
-      fontSize: pick({ mobile: '16px', tabletA9: '20px', desktop: '22px' }), padding: '3px 8px', borderRadius: '6px', 
+      fontSize: pick({ mobile: '15px', tabletA9: '20px', desktop: '22px' }), padding: '3px 8px', borderRadius: '6px', 
       backgroundColor: RAIM_COLORS.TEAL + '22', color: '#0F766E', 
       fontWeight: '700', border: `1px solid ${RAIM_COLORS.TEAL}44`, 
       whiteSpace: 'nowrap', flexShrink: 0 
     },
     badgeManual: { 
       display:'inline-flex', alignItems:'center', justifyContent:'center', 
-      fontSize: pick({ mobile: '16px', tabletA9: '20px', desktop: '22px' }), padding: '3px 8px', borderRadius: '6px', 
+      fontSize: pick({ mobile: '15px', tabletA9: '20px', desktop: '22px' }), padding: '3px 8px', borderRadius: '6px', 
       backgroundColor: '#F3F4F6', color: '#4B5563', fontWeight: '700', 
       border: '1px solid #E5E7EB', whiteSpace: 'nowrap', flexShrink: 0 
     },
@@ -103,7 +119,7 @@ const getStyles = (device) => {
       border: 'none',
       borderRadius: '8px',
       cursor: 'pointer',
-      fontSize: '22px',
+      fontSize: pick({ mobile: '15px', tabletA9: '20px', desktop: '22px' }),
       fontWeight: 'bold'
     },
     quantityButtonPlus: {
@@ -115,16 +131,16 @@ const getStyles = (device) => {
       color: RAIM_COLORS.MUTED
     },
     quantityText: {
-      fontSize: '28px',
+      fontSize: pick({ mobile: '15px', tabletA9: '26px', desktop: '28px' }),
       fontWeight: '600',
       color: RAIM_COLORS.DARK,
-      minWidth: '30px',
+      minWidth: pick({ mobile: '24px', tabletA9: '28px', desktop: '30px' }),
       textAlign: 'center'
     }
   };
 };
 
-export default function VisitorList({ visitors, onRemove, onAdd }) {
+export default function VisitorList({ visitors, onRemove, onAdd, onReset }) {
   const { t } = useTranslation();
   const { device } = useIsMobile();
   const styles = getStyles(device);
@@ -192,7 +208,18 @@ export default function VisitorList({ visitors, onRemove, onAdd }) {
           <ClipboardList size={30} color={RAIM_COLORS.DARK} />
           <h3 style={styles.cardTitle}>{t('visitorList.title')}</h3>
         </div>
-        <span style={styles.countBadge}>{t('common.peopleCount', { count: visitors.length })}</span>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          {visitors.length > 0 && (
+            <button 
+              onClick={onReset}
+              style={styles.resetButton}
+            >
+              <RotateCcw size={16} />
+              {t('visitorList.resetButton')}
+            </button>
+          )}
+          <span style={styles.countBadge}>{t('common.peopleCount', { count: visitors.length })}</span>
+        </div>
       </div>
       
       <div style={styles.listContainer}>
@@ -214,7 +241,7 @@ export default function VisitorList({ visitors, onRemove, onAdd }) {
                       {t(`ageGroups.${getAgeGroupKey(groupedVisitor.ageGroup)}`)}
                       {groupedVisitor.count > 1 && (
                         <span style={{ 
-                          fontSize: '22px', 
+                          fontSize: device === 'mobile' ? '12px' : device === 'tabletA9' ? '18px' : '20px', 
                           color: RAIM_COLORS.MEDIUM, 
                           fontWeight: '600',
                           marginLeft: '6px'

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -44,7 +44,8 @@
     "title": "Registration List",
     "emptyState": "No visitors registered",
     "aiTag": "AI",
-    "manualTag": "Manual"
+    "manualTag": "Manual",
+    "resetButton": "Reset"
   },
   "scanConfirm": {
     "title": "Confirm Scan Results",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -44,13 +44,14 @@
     "title": "등록 목록",
     "emptyState": "등록된 관람객이 없습니다",
     "aiTag": "AI",
-    "manualTag": "수동"
+    "manualTag": "수동",
+    "resetButton": "초기화"
   },
   "scanConfirm": {
     "title": "스캔 결과 확인",
     "detected": "{{count}}명 인식됨",
     "editInfo": "정보가 올바르지 않다면, 수정할 수 있습니다",
-    "confirmButton": "등록",
+    "confirmButton": "확인",
     "cancelButton": "수정"
   },
   "successModal": {


### PR DESCRIPTION
## 📋 Summary
모달 UX 개선 및 초기화 기능 추가

## 🛠 Key Changes
**1. 스캔 확인 모달 버튼 배치 개선**
-  일반적인 UI 관례에 따라 확인 버튼을 오른쪽으로 이동
- 취소/수정 버튼은 왼쪽에 배치
**2. 등록 완료 모달 자동 닫기**
- 등록 완료 후 3초 뒤 자동으로 모달이 닫히도록 개선
- 사용자가 수동으로 닫기 버튼을 누를 필요 없이 원활한 흐름 제공
**3. 등록 목록 초기화 버튼 추가**
-  명수 표시 왼쪽에 초기화 버튼 추가
-  등록된 방문객이 있을 때만 표시
-  반응형 디자인 적용
**4. 반응형 스타일 개선**
-  수량 표시 텍스트의 디바이스별 반응형 스타일 적용
-  일관된 사용자 경험 제공

## 📸 Screenshots
<img width="431" height="853" alt="{904391E2-5C56-4FF0-B568-6DACB816F2D3}" src="https://github.com/user-attachments/assets/c7edcb8d-46cd-4d47-a6f5-e16650bf826c" />