### PR TITLE
🐛 fix: 연령대 분류 기준 변경 및 버그 수정

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,17 +2,13 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
-import { defineConfig, globalIgnores } from 'eslint/config'
 
-export default defineConfig([
-  globalIgnores(['dist']),
+export default [
+  {
+    ignores: ['dist/**', 'build/**', 'node_modules/**'],
+  },
   {
     files: ['**/*.{js,jsx}'],
-    extends: [
-      js.configs.recommended,
-      reactHooks.configs.flat.recommended,
-      reactRefresh.configs.vite,
-    ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
@@ -22,8 +18,18 @@ export default defineConfig([
         sourceType: 'module',
       },
     },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
     rules: {
+      ...js.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
-])
+]

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,7 +38,7 @@ function App() {
   const [scannedVisitors, setScannedVisitors] = useState([]);
 
   const [manualGender, setManualGender] = useState('male');
-  const [manualGroup, setManualGroup] = useState('청년');
+  const [manualGroup, setManualGroup] = useState('유아');
   const [isAIMode, setIsAIMode] = useState(true);
 
   // 로고 클릭 추적 (3회 클릭으로 대시보드 열기)
@@ -378,8 +378,14 @@ function App() {
     setIsAIMode((prev) => !prev);
   };
 
-  const addManualVisitor = () => {
-    const newVisitor = {
+  const addManualVisitor = (visitorData) => {
+    // 이벤트 객체가 전달된 경우 무시
+    const isValidVisitorData = visitorData && 
+      typeof visitorData === 'object' && 
+      !visitorData.nativeEvent && 
+      (visitorData.ageGroup || visitorData.gender);
+    
+    const newVisitor = isValidVisitorData ? visitorData : {
       id: Date.now() + Math.random(),
       ageGroup: manualGroup,
       gender: manualGender,

--- a/src/components/ManualEntryCard.jsx
+++ b/src/components/ManualEntryCard.jsx
@@ -161,7 +161,7 @@ export default function ManualEntryCard({
         </div>
       </div>
 
-      <button onClick={onAdd} style={styles.addButton}>
+      <button onClick={() => onAdd()} style={styles.addButton}>
         <span>{t('manualEntry.addButton')}</span>
         <ArrowDown size={24} strokeWidth={3} />
       </button>

--- a/src/components/ScanConfirmModal.jsx
+++ b/src/components/ScanConfirmModal.jsx
@@ -186,20 +186,20 @@ export default function ScanConfirmModal({
   // 한글 연령대를 번역 키로 매핑
   const getAgeGroupKey = (ageGroup) => {
     const mapping = {
-      '영유아': 'infant',
-      '영유아(0~7세)': 'infant',
+      '유아': 'infant',
+      '유아(0~6세)': 'infant',
       '어린이': 'child',
-      '어린이(8~13세)': 'child',
+      '어린이(7~12세)': 'child',
       '청소년': 'teen',
-      '청소년(14~19세)': 'teen',
+      '청소년(13~19세)': 'teen',
       '청년': 'youth',
-      '청년(20~34세)': 'youth',
+      '청년(20~39세)': 'youth',
       '중년': 'middleAge',
-      '중년(35~59세)': 'middleAge',
+      '중년(40~64세)': 'middleAge',
       '노년': 'senior',
-      '노년(60세 이상)': 'senior',
-      '장년': 'senior',
-      '장년(50세~)': 'senior'
+      '노년(65세 이상)': 'senior',
+      '영유아': 'infant', // 레거시 지원
+      '장년': 'senior' // 레거시 지원
     };
     return mapping[ageGroup] || 'youth';
   };

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,23 +14,24 @@ export const RAIM_COLORS = {
 };
 
 export const ageGroups = [
-  { label: "영유아", sub: "0~7세", key: "infant" },
-  { label: "어린이", sub: "8~13세", key: "child" },
-  { label: "청소년", sub: "14~19세", key: "teen" },
-  { label: "청년", sub: "20~34세", key: "youth" },
-  { label: "중년", sub: "35~59세", key: "middleAge" },
-  { label: "노년", sub: "60세 이상", key: "senior" }
+  { label: "유아", sub: "0~6세", key: "infant" },
+  { label: "어린이", sub: "7~12세", key: "child" },
+  { label: "청소년", sub: "13~19세", key: "teen" },
+  { label: "청년", sub: "20~39세", key: "youth" },
+  { label: "중년", sub: "40~64세", key: "middleAge" },
+  { label: "노년", sub: "65세 이상", key: "senior" }
 ];
 
 // 나이 그룹 라벨 매핑 (최적화: 매번 문자열 비교 대신 맵 사용)
 export const AGE_GROUP_LABELS = {
-  '영유아': '영유아(0~7세)',
-  '어린이': '어린이(8~13세)',
-  '청소년': '청소년(14~19세)',
-  '청년': '청년(20~34세)',
-  '중년': '중년(35~59세)',
-  '노년': '노년(60세 이상)',
-  '장년': '노년(60세 이상)' // 레거시 지원
+  '유아': '유아(0~6세)',
+  '어린이': '어린이(7~12세)',
+  '청소년': '청소년(13~19세)',
+  '청년': '청년(20~39세)',
+  '중년': '중년(40~64세)',
+  '노년': '노년(65세 이상)',
+  '영유아': '유아(0~6세)', // 레거시 지원
+  '장년': '노년(65세 이상)' // 레거시 지원
 };
 
 export const roomLocations = [

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,5 +1,4 @@
 import { initializeApp } from "firebase/app";
-import { getAnalytics } from "firebase/analytics";
 import { getFirestore, collection, addDoc, serverTimestamp } from "firebase/firestore";
 
 const firebaseConfig = {
@@ -17,11 +16,31 @@ const missingKeys = Object.entries(firebaseConfig)
   .map(([key]) => key);
 
 if (missingKeys.length) {
-  throw new Error(`Missing Firebase env vars: ${missingKeys.join(", ")}`);
+  const errorMsg = `
+❌ Firebase 환경변수가 설정되지 않았습니다!
+
+누락된 환경변수:
+${missingKeys.map(key => `  - ${key}`).join('\n')}
+
+해결 방법:
+1. 프로젝트 루트에 .env 파일을 생성하세요
+2. 다음 변수들을 설정하세요:
+   VITE_FIREBASE_API_KEY=your_api_key
+   VITE_FIREBASE_AUTH_DOMAIN=your_auth_domain
+   VITE_FIREBASE_PROJECT_ID=your_project_id
+   VITE_FIREBASE_STORAGE_BUCKET=your_storage_bucket
+   VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+   VITE_FIREBASE_APP_ID=your_app_id
+   VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
+3. 개발 서버를 재시작하세요 (npm run dev)
+
+자세한 내용은 README.md를 참고하세요.
+`;
+  console.error(errorMsg);
+  throw new Error(`Missing Firebase environment variables: ${missingKeys.join(", ")}`)
 }
 
 const app = initializeApp(firebaseConfig);
-const analytics = getAnalytics(app);
 const db = getFirestore(app);
 
 export { db, collection, addDoc, serverTimestamp };

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -16,18 +16,18 @@
     "peopleCount": "{{count}}"
   },
   "ageGroups": {
-    "infant": "Infant",
-    "infantSub": "0~7 years",
+    "infant": "Toddler",
+    "infantSub": "0~6 years",
     "child": "Child",
-    "childSub": "8~13 years",
+    "childSub": "7~12 years",
     "teen": "Teen",
-    "teenSub": "14~19 years",
+    "teenSub": "13~19 years",
     "youth": "Youth",
-    "youthSub": "20~34 years",
+    "youthSub": "20~39 years",
     "middleAge": "Middle Age",
-    "middleAgeSub": "35~59 years",
+    "middleAgeSub": "40~64 years",
     "senior": "Senior",
-    "seniorSub": "60+ years"
+    "seniorSub": "65+ years"
   },
   "camera": {
     "privacyNotice": "Images are not stored",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -16,18 +16,18 @@
     "peopleCount": "{{count}}명"
   },
   "ageGroups": {
-    "infant": "영유아",
-    "infantSub": "0~7세",
+    "infant": "유아",
+    "infantSub": "0~6세",
     "child": "어린이",
-    "childSub": "8~13세",
+    "childSub": "7~12세",
     "teen": "청소년",
-    "teenSub": "14~19세",
+    "teenSub": "13~19세",
     "youth": "청년",
-    "youthSub": "20~34세",
+    "youthSub": "20~39세",
     "middleAge": "중년",
-    "middleAgeSub": "35~59세",
+    "middleAgeSub": "40~64세",
     "senior": "노년",
-    "seniorSub": "60세 이상"
+    "seniorSub": "65세 이상"
   },
   "camera": {
     "privacyNotice": "이미지는 저장되지 않습니다",

--- a/src/utils/ageConverter.js
+++ b/src/utils/ageConverter.js
@@ -1,9 +1,9 @@
 export const convertToGroup = (age, correction = 4) => {
   const kAge = age + correction;
-  if (kAge <= 6) return "영유아";
-  if (kAge <= 12) return "어린이";
-  if (kAge <= 19) return "청소년";
-  if (kAge <= 39) return "청년";
-  if (kAge <= 49) return "중년";
-  return "장년";
+  if (kAge <= 6) return "유아";     // 0~6세
+  if (kAge <= 12) return "어린이";  // 7~12세
+  if (kAge <= 19) return "청소년";  // 13~19세
+  if (kAge <= 39) return "청년";    // 20~39세
+  if (kAge <= 64) return "중년";    // 40~64세
+  return "노년";                     // 65세 이상
 };

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,8 +28,9 @@ export default defineConfig({
     exclude: []
   },
   esbuild: {
-    // esbuild 최적화 옵션
-    drop: ['console', 'debugger'], // console.log 제거
+    // esbuild 최적화 옵션 (에러 디버깅을 위해 console.error와 console.warn은 유지)
+    drop: ['debugger'],
+    pure: ['console.log', 'console.info', 'console.debug'],
     legalComments: 'none'
   }
 })


### PR DESCRIPTION
## 📋 Summary
연령대 분류 기준 변경 및 코드 리뷰를 통해 발견된 버그를 수정했습니다.

## 🛠 Key Changes
**1.  연령대 분류 기준 변경**
- **이전**: 영유아(0 ~ 7세), 어린이(8 ~ 13세), 청소년(14 ~ 19세), 청년(20 ~ 34세), 중년(35 ~ 59세), 노년(60세+)
- **변경**: 유아(0 ~ 6세), 어린이(7 ~ 12세), 청소년(13 ~ 19세), 청년(20 ~ 39세), 중년(40 ~ 64세), 노년(65세 이상)

**2. 성능 최적화**
- `VisitorList.jsx`: `groupedVisitors` 계산을 `useMemo`로 감싸 불필요한 재계산 방지

**3. 개발 환경 개선**
- **Firebase 초기화 오류 메시지**: 누락된 환경변수를 명확하게 표시하고 해결 방법 안내
- **ESLint 설정**: 구버전 문법에서 ESLint 9 flat config로 마이그레이션
- **Vite 빌드 설정**: `console.error`와 `console.warn`은 유지하고 `console.log`만 제거하도록 개선
- **Firebase Analytics**: 미사용 코드 제거

## 📸 Screenshots
<img width="623" height="930" alt="{563C75AE-8F91-44EF-AA00-E5475824295B}" src="https://github.com/user-attachments/assets/8df6915c-f3cf-4fda-9c02-3214f67b4254" />